### PR TITLE
[HWORKS-664] Use Java tmpdir instead of /tmp

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@ default['hive2']['lib_dir']                 = node['hive2']['base_dir'] + "/lib"
 default['hive2']['hopsworks_jars']          = node['hive2']['base_dir'] + "/hopsworks-jars"
 default['hive2']['consul']                  = node['hive2']['base_dir'] + "/consul"
 default['hive2']['hopsfs_dir']              = "#{node['hops']['hdfs']['apps_dir']}/hive"
-default['hive2']['scratch_dir']             = "/tmp/hive"
+default['hive2']['scratch_dir']             = "${system:java.io.tmpdir}/hive"
 
 # Data volume directories
 default['hive2']['data_volume']['root_dir'] = "#{node['data']['dir']}/apache-hive"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@ default['hive2']['lib_dir']                 = node['hive2']['base_dir'] + "/lib"
 default['hive2']['hopsworks_jars']          = node['hive2']['base_dir'] + "/hopsworks-jars"
 default['hive2']['consul']                  = node['hive2']['base_dir'] + "/consul"
 default['hive2']['hopsfs_dir']              = "#{node['hops']['hdfs']['apps_dir']}/hive"
-default['hive2']['scratch_dir']             = "${system:java.io.tmpdir}/hive"
+default['hive2']['scratch_dir']             = "/tmp/hive"
 
 # Data volume directories
 default['hive2']['data_volume']['root_dir'] = "#{node['data']['dir']}/apache-hive"

--- a/templates/default/hive-site.xml.erb
+++ b/templates/default/hive-site.xml.erb
@@ -74,7 +74,7 @@
   </property>
   <property>
     <name>hive.downloaded.resources.dir</name>
-    <value>/tmp/hive/${hive.session.id}_resources</value>
+    <value>${system:java.io.tmpdir}/hive/${hive.session.id}_resources</value>
     <description>Temporary local directory for added resources in the remote file system.</description>
   </property>
   <property>
@@ -4637,7 +4637,7 @@
   </property>
   <property>
     <name>hive.llap.io.allocator.mmap.path</name>
-    <value>/tmp</value>
+    <value>${system:java.io.tmpdir}</value>
     <description>
       Expects a writable directory on the local filesystem.
       The directory location for mapping NVDIMM/NVMe flash storage into the ORC low-level cache.


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/HWORKS-664