### PR TITLE
[HWORKS-664] Use Java property for tmp instead of /tmp

### DIFF
--- a/templates/default/hive-site.xml.erb
+++ b/templates/default/hive-site.xml.erb
@@ -69,12 +69,12 @@
   </property>
   <property>
     <name>hive.exec.local.scratchdir</name>
-    <value>/tmp/<%= node['hive2']['user'] %></value>
+    <value>${java.io.tmpdir}/<%= node['hive2']['user'] %></value>
     <description>Local scratch space for Hive jobs</description>
   </property>
   <property>
     <name>hive.downloaded.resources.dir</name>
-    <value>/tmp/hive/${hive.session.id}_resources</value>
+    <value>${java.io.tmpdir}/hive/${hive.session.id}_resources</value>
     <description>Temporary local directory for added resources in the remote file system.</description>
   </property>
   <property>
@@ -4540,7 +4540,7 @@
   </property>
   <property>
     <name>hive.llap.io.allocator.mmap.path</name>
-    <value>/tmp</value>
+    <value>${java.io.tmpdir}</value>
     <description>
       Expects a writable directory on the local filesystem.
       The directory location for mapping NVDIMM/NVMe flash storage into the ORC low-level cache.


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/HWORKS-664